### PR TITLE
Add Github templates (PRs, Issues, Contributing guide)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to SwiftyPick
+
+🦅🍒 First off, thanks for taking the time to contribute! 🍒🦅
+
+The following is a set of guidelines for contributing to `SwiftyPick`, which is hosted on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## What should I know before I get started?
+
+The only thing that you need to do before contributing is to check whether the thing (feature, code sample, test, etc) you want to add has not been already added to the project.  
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+If you find a bug in the code, feel free to create a new Github Issue:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. When listing steps, **don't just say what you did, but explain how you did it**.
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.
+* **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened.
+
+### Pull Requests
+
+The process described here has several goals:
+
+- Maintain `SwiftyPick`'s quality
+- Engage the community in working toward the best possible `SwiftyPick`s
+- Enable a sustainable system for `SwiftyPick`'s maintainers to review contributions
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+2. Follow the [styleguides](#styleguides)
+3. Before merging, the branch should be rebased to latest `main`. This is a requirement to guarantee an easy to read history on the repository.
+
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+
+## Styleguides
+
+### Git Commit Messages
+
+* Use the present tense ("Add feature" instead of "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 80 characters or less
+* Reference issues and pull requests liberally after the first line
+* Consider starting the commit message with an applicable emoji:
+    * :art: `:art:` when improving the format/structure of the code
+    * :racehorse: `:racehorse:` when improving performance
+    * :non-potable_water: `:non-potable_water:` when plugging memory leaks
+    * :memo: `:memo:` when writing docs
+    * :bug: `:bug:` when fixing a bug
+    * :scissors: `:scissors:` when removing code or files
+    * :test_tube: `:test_tube:` when adding tests
+    * :lock: `:lock:` when dealing with security
+    * :arrow_up: `:arrow_up:` when upgrading dependencies
+    * :arrow_down: `:arrow_down:` when downgrading dependencies
+    * :shirt: `:shirt:` when removing linter warnings
+
+### Swift Styleguide
+
+* Follow the rules specified by the swiftlint rules file 🚓
+
+### Documentation Styleguide
+
+* When adding new functionality, it's important to add a new markdown file under `Documentation/` explaining how to cherry-pick that functionality into another project.
+* It's also important to add a new entry in the `README` referencing the new doc.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+## 💥 Issue and Steps to Reproduce
+<!-- Describe your issue providing as much information as you can -->
+
+
+### 😬 Expected Behavior
+
+
+### 🤯 Actual Behavior
+
+
+<!-- Beginning of comment block
+
+## 📱 Screenshots
+
+| Left | Right |
+|-|-|
+|<img src="URL" width="400px">|<img src="URL" width="400px">|
+
+## 📼 Video walkthrough
+
+## 🧪 Testing
+
+## ✅ Checklist
+
+End of comment block -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## 👋 Intro
+<!-- Include a summary of the change -->
+
+
+## 🤔 What changed?
+<!-- Overview of the things that changed -->
+<!-- provide code snippets if necessary -->
+*
+*
+
+## 🍒 How to cherry-pick to another project
+<!-- Include a guide to use these changes in a different project -->
+1. 
+2.
+3.
+
+## ✅ Checklist
+- [ ] Documentation on how to cherry-pick to another project added in `Documentation/`
+- [ ] `README` updated
+- [ ] **Tests** added for the new additions
+
+<!-- Beginning of comment block
+
+## 📱 Screenshots
+
+| Left | Right |
+|-|-|
+|<img src="URL" width="400px">|<img src="URL" width="400px">|
+
+## 📼 Video walkthrough
+
+## 🧪 Testing
+
+End of comment block -->

--- a/Documentation/GithubTemplates.md
+++ b/Documentation/GithubTemplates.md
@@ -1,0 +1,25 @@
+# Github Templates
+
+The purpose of this document is to be a step by step guide on how to add Github Templates to your project.
+
+* [Github documentation](https://github.blog/2016-02-17-issue-and-pull-request-templates/)
+
+You can also have multiple templates inside your projects:
+
+* [Article](https://github.blog/2018-01-25-multiple-issue-and-pull-request-templates/) on how to set it up.
+
+## Steps
+1. Create a `.github` directory in the root of your project
+2. Inside that directory, add the templates you want. 
+
+## Cherry-Pick the PR Template
+1. Create a `PULL_REQUEST_TEMPLATE.md` file under the `.github` directory.
+2. Use the contents on the [PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md) file as inspiration for your own template. 
+
+## Cherry-Pick the Issue Template
+1. Create a `ISSUE_TEMPLATE.md` file under the `.github` directory.
+2. Use the contents on the [ISSUE_TEMPLATE.md](../.github/ISSUE_TEMPLATE.md) file as inspiration for your own template. 
+
+## Cherry-Pick the Contribution Guide
+1. Create a `CONTRIBUTING.md` file under the `.github` directory.
+2. Use the contents on the [CONTRIBUTING.md](../.github/CONTRIBUTING.md) file as inspiration for your own template. 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# SwiftyPick
-Useful Swift code samples, extensions, functionalities and scripts to cherry-pick and use in your projects
+# SwiftyPick 🦅🍒
+
+Useful Swift code samples, extensions, functionalities and scripts to cherry-pick and use in your projects.
+
+## Purpose
+
+The idea behind this project is not to be a `pod` that users import into their own projects, but rather a collection of useful ideas, well-organized and documented, to cherry-pick as needed into another projects.
+Every new piece of functionality will have a proper document explaining it's usage under the `Documentation` directory.
+
+# Features 🚀
+
+<!-- Comment block
+## Code
+
+### Extensions
+
+### Features
+
+### Networking
+
+### UI
+-->
+
+## Process
+
+### Github
+
+#### [Set up PR and Issue templates](Documentation/GithubTemplates.md)
+Step by step guide on how to add a Pull Request or Issue template to your project.
+
+<!-- ### Scripts -->
+
+# Contributing
+
+Check out the [Contributing guide](.github/CONTRIBUTING.md)

--- a/SwiftyPick.xcodeproj/project.pbxproj
+++ b/SwiftyPick.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A044B10026D67D350051EDEA /* GithubTemplates.md in Resources */ = {isa = PBXBuildFile; fileRef = A044B0FF26D67D340051EDEA /* GithubTemplates.md */; };
+		A044B10226D67D470051EDEA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = A044B10126D67D470051EDEA /* README.md */; };
 		A06890CA26D5D7A700D1BC36 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06890C926D5D7A700D1BC36 /* AppDelegate.swift */; };
 		A06890CC26D5D7A700D1BC36 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06890CB26D5D7A700D1BC36 /* SceneDelegate.swift */; };
 		A06890CE26D5D7A700D1BC36 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06890CD26D5D7A700D1BC36 /* ViewController.swift */; };
@@ -34,6 +36,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A044B0FF26D67D340051EDEA /* GithubTemplates.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = GithubTemplates.md; sourceTree = "<group>"; };
+		A044B10126D67D470051EDEA /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A06890C626D5D7A700D1BC36 /* SwiftyPick.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftyPick.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A06890C926D5D7A700D1BC36 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A06890CB26D5D7A700D1BC36 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -74,9 +78,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A044B0FE26D67D340051EDEA /* Documentation */ = {
+			isa = PBXGroup;
+			children = (
+				A044B0FF26D67D340051EDEA /* GithubTemplates.md */,
+			);
+			path = Documentation;
+			sourceTree = "<group>";
+		};
 		A06890BD26D5D7A700D1BC36 = {
 			isa = PBXGroup;
 			children = (
+				A044B10126D67D470051EDEA /* README.md */,
+				A044B0FE26D67D340051EDEA /* Documentation */,
 				A06890C826D5D7A700D1BC36 /* SwiftyPick */,
 				A06890DF26D5D7A900D1BC36 /* SwiftyPickTests */,
 				A06890EA26D5D7A900D1BC36 /* SwiftyPickUITests */,
@@ -229,6 +243,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A06890D626D5D7A900D1BC36 /* LaunchScreen.storyboard in Resources */,
+				A044B10026D67D350051EDEA /* GithubTemplates.md in Resources */,
+				A044B10226D67D470051EDEA /* README.md in Resources */,
 				A06890D326D5D7A900D1BC36 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## 👋 Intro
<!-- Include a summary of the change -->
Create templates for:
* New Pull Requests
* New Issues
* Contribution guide

## 🤔 What changed?
<!-- Overview of the things that changed -->
<!-- provide code snippets if necessary -->
* Added the 3 new templates
* Added the `Documentation` directory and the `README` file to the Xcode project for easier maintenance

## 🍒 How to cherry-pick to another project
<!-- Include a guide to use these changes in a different project -->
See instructions in the [docs](Documentation/GithubTemplates.md)

## ✅ Checklist
- [X] Documentation on how to cherry-pick to another project added in `Documentation/`
- [X] `README` updated