### PR TITLE
🐛 Move all colors to use Display-P3 color-space

### DIFF
--- a/SwiftyPick/Presentation/Extension/UIColor+Hex.swift
+++ b/SwiftyPick/Presentation/Extension/UIColor+Hex.swift
@@ -11,23 +11,6 @@ extension UIColor {
     /// Returns the hex of a color. For example: `#FFFFFF`.
     /// - Returns: The hex string for this `UIColor`.
     func hexString() -> String? {
-        guard let model = cgColor.colorSpace?.model else {
-            return nil
-        }
-
-        switch model {
-        case .rgb:
-            return rgbHex()
-        case .monochrome:
-            return monochromeHex()
-        default:
-            return nil
-        }
-    }
-}
-
-private extension UIColor {
-    func rgbHex() -> String {
         let components = cgColor.components
 
         let red: CGFloat = components?[0] ?? 0.0
@@ -41,18 +24,5 @@ private extension UIColor {
             lroundf(Float(blue * 255))
         )
         return hexString
-    }
-
-    func monochromeHex() -> String {
-        let components = cgColor.components
-
-        let greyScale: CGFloat = components?[0] ?? 0.0
-
-        // We only have black and white as monochrome, so we will hack this for now:
-        if greyScale == 1.0 {
-            return "#FFFFFF"
-        } else {
-            return "#000000"
-        }
     }
 }

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/backgroundAlt.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/backgroundAlt.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "ios",
-        "reference" : "labelColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
       },
       "idiom" : "universal"
     },
@@ -15,8 +20,13 @@
         }
       ],
       "color" : {
-        "platform" : "ios",
-        "reference" : "labelColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
       },
       "idiom" : "universal"
     }

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/backgroundMain.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/backgroundMain.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemBackgroundColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
       },
       "idiom" : "universal"
     },
@@ -15,8 +20,13 @@
         }
       ],
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemBackgroundColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
       },
       "idiom" : "universal"
     }

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/backgroundMid.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/backgroundMid.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemGray4Color"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.837",
+          "green" : "0.820",
+          "red" : "0.820"
+        }
       },
       "idiom" : "universal"
     },
@@ -15,8 +20,13 @@
         }
       ],
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemGray4Color"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.234",
+          "green" : "0.227",
+          "red" : "0.227"
+        }
       },
       "idiom" : "universal"
     }

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/primary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/primary.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x1E",
-          "green" : "0x13",
-          "red" : "0xF6"
+          "blue" : "0x2E",
+          "green" : "0x35",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3C",
-          "green" : "0x33",
-          "red" : "0xF8"
+          "blue" : "0x2E",
+          "green" : "0x36",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/secondary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/secondary.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x99",
-          "green" : "0x75",
-          "red" : "0x46"
+          "blue" : "0x95",
+          "green" : "0x73",
+          "red" : "0x50"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB2",
-          "green" : "0x8B",
-          "red" : "0x57"
+          "blue" : "0xAE",
+          "green" : "0x89",
+          "red" : "0x62"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/tertiary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/tertiary.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xDB",
-          "green" : "0xCA",
-          "red" : "0x57"
+          "blue" : "0xD8",
+          "green" : "0xC7",
+          "red" : "0x76"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE6",
-          "green" : "0xD9",
-          "red" : "0x88"
+          "blue" : "0xE3",
+          "green" : "0xD6",
+          "red" : "0x9A"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/textAlt.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/textAlt.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemBackgroundColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
       },
       "idiom" : "universal"
     },
@@ -15,8 +20,13 @@
         }
       ],
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemBackgroundColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
       },
       "idiom" : "universal"
     }

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Default/textPrimary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Default/textPrimary.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "ios",
-        "reference" : "labelColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
       },
       "idiom" : "universal"
     },
@@ -15,8 +20,13 @@
         }
       ],
       "color" : {
-        "platform" : "ios",
-        "reference" : "labelColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
       },
       "idiom" : "universal"
     }

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/backgroundAlt.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/backgroundAlt.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.268",
-          "green" : "0.106",
-          "red" : "0.108"
+          "blue" : "0x41",
+          "green" : "0x1B",
+          "red" : "0x1B"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.985",
-          "green" : "0.388",
-          "red" : "0.398"
+          "blue" : "0xF2",
+          "green" : "0x63",
+          "red" : "0x65"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/backgroundMain.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/backgroundMain.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "extended-srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.966",
-          "green" : "0.896",
-          "red" : "0.025"
+          "blue" : "0xF3",
+          "green" : "0xE1",
+          "red" : "0x68"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.270",
-          "green" : "0.199",
-          "red" : "0.117"
+          "blue" : "0x43",
+          "green" : "0x32",
+          "red" : "0x22"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/backgroundMid.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/backgroundMid.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "ios",
-        "reference" : "systemBlueColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0x77",
+          "red" : "0x34"
+        }
       },
       "idiom" : "universal"
     },
@@ -15,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.445",
-          "green" : "0.227",
-          "red" : "0.015"
+          "blue" : "0.430",
+          "green" : "0.223",
+          "red" : "0.089"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/primary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/primary.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.118",
-          "green" : "0.075",
-          "red" : "0.965"
+          "blue" : "0x2E",
+          "green" : "0x36",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.235",
-          "green" : "0.200",
-          "red" : "0.973"
+          "blue" : "0x2E",
+          "green" : "0x36",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/secondary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/secondary.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.600",
-          "green" : "0.851",
-          "red" : "0.275"
+          "blue" : "0x9D",
+          "green" : "0xD6",
+          "red" : "0x73"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.558",
-          "green" : "0.642",
-          "red" : "0.087"
+          "blue" : "0x8E",
+          "green" : "0xA1",
+          "red" : "0x4C"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/tertiary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/tertiary.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.859",
-          "green" : "0.551",
-          "red" : "0.912"
+          "blue" : "0xD6",
+          "green" : "0x90",
+          "red" : "0xDB"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.902",
-          "green" : "0.382",
-          "red" : "0.746"
+          "blue" : "0xDF",
+          "green" : "0x66",
+          "red" : "0xB2"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/textAlt.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/textAlt.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.779",
-          "green" : "0.779",
-          "red" : "0.779"
+          "blue" : "0xC6",
+          "green" : "0xC5",
+          "red" : "0xC6"
         }
       },
       "idiom" : "universal"
@@ -20,10 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "extended-gray",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "white" : "0.250"
+          "blue" : "0x3F",
+          "green" : "0x3F",
+          "red" : "0x3F"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/textPrimary.colorset/Contents.json
+++ b/SwiftyPick/Resources/Assets/Color.xcassets/Flashy/textPrimary.colorset/Contents.json
@@ -2,10 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "extended-gray",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "white" : "0.250"
+          "blue" : "0x3F",
+          "green" : "0x3F",
+          "red" : "0x3F"
         }
       },
       "idiom" : "universal"
@@ -18,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.779",
-          "green" : "0.779",
-          "red" : "0.779"
+          "blue" : "0xC6",
+          "green" : "0xC5",
+          "red" : "0xC6"
         }
       },
       "idiom" : "universal"

--- a/SwiftyPickTests/Resources/ColorTests.swift
+++ b/SwiftyPickTests/Resources/ColorTests.swift
@@ -35,13 +35,13 @@ class ColorTests: XCTestCase {
         let palette = UIColor.Palette.default
         let all = [
             ColorTuple(palette.backgroundMain, "#FFFFFF"),
-            ColorTuple(palette.backgroundMid, "#D1D1D6"),
+            ColorTuple(palette.backgroundMid, "#D1D1D5"),
             ColorTuple(palette.backgroundAlt, "#000000"),
             ColorTuple(palette.textPrimary, "#000000"),
             ColorTuple(palette.textAlt, "#FFFFFF"),
-            ColorTuple(palette.primary, "#F6131E"),
-            ColorTuple(palette.secondary, "#467599"),
-            ColorTuple(palette.tertiary, "#57CADB")
+            ColorTuple(palette.primary, "#E1352E"),
+            ColorTuple(palette.secondary, "#507395"),
+            ColorTuple(palette.tertiary, "#76C7D8")
         ]
 
         assertHexAndColorMatch(all)
@@ -50,14 +50,14 @@ class ColorTests: XCTestCase {
     private func assertFlashyHexadecimals() {
         let palette = UIColor.Palette.flashy
         let all = [
-            ColorTuple(palette.backgroundMain, "#06E4F6"),
-            ColorTuple(palette.backgroundMid, "#007AFF"),
-            ColorTuple(palette.backgroundAlt, "#1C1B44"),
-            ColorTuple(palette.textPrimary, "#000000"),
-            ColorTuple(palette.textAlt, "#C7C7C7"),
-            ColorTuple(palette.primary, "#F6131E"),
-            ColorTuple(palette.secondary, "#46D999"),
-            ColorTuple(palette.tertiary, "#E98DDB")
+            ColorTuple(palette.backgroundMain, "#68E1F3"),
+            ColorTuple(palette.backgroundMid, "#3477F6"),
+            ColorTuple(palette.backgroundAlt, "#1B1B41"),
+            ColorTuple(palette.textPrimary, "#3F3F3F"),
+            ColorTuple(palette.textAlt, "#C6C5C6"),
+            ColorTuple(palette.primary, "#E1362E"),
+            ColorTuple(palette.secondary, "#73D69D"),
+            ColorTuple(palette.tertiary, "#DB90D6")
         ]
 
         assertHexAndColorMatch(all)


### PR DESCRIPTION
## 👋 Intro
<!-- Include a summary of the change -->
The method to retrieve the hexadecimal of the colors was failing to retrieve the correct hexa for Apple's semantic colors, so this PR moves all the colors to use Display P3 as their color-space

## 🤔 What changed?
<!-- Overview of the things that changed -->
<!-- provide code snippets if necessary -->
* Fixed bugs with hexadecimals
* Fixed the tests
* Added consistency by always using the same color-space